### PR TITLE
chore: upgrade to latest image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         image: 
-          - "ghcr.io/ivarconr/unleash-enterprise:5.5.6-terraform.0"
+          - "ghcr.io/ivarconr/unleash-enterprise:latest"
           - "unleashorg/unleash-server:latest"
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Just getting rid of the pre-release reference