### PR TITLE
chore: drop support for 5.8 and below, add support for 6.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,13 +17,7 @@ jobs:
   build:
     strategy:
       matrix:
-        image: 
-          - "ghcr.io/ivarconr/unleash-enterprise:5.6"
-          - "unleashorg/unleash-server:5.6"
-          - "ghcr.io/ivarconr/unleash-enterprise:5.7"
-          - "unleashorg/unleash-server:5.7"
-          - "ghcr.io/ivarconr/unleash-enterprise:5.8"
-          - "unleashorg/unleash-server:5.8"
+        image:
           - "ghcr.io/ivarconr/unleash-enterprise:5.9"
           - "unleashorg/unleash-server:5.9"
           - "ghcr.io/ivarconr/unleash-enterprise:5.10"
@@ -34,6 +28,8 @@ jobs:
           - "unleashorg/unleash-server:5.12"
           - "ghcr.io/ivarconr/unleash-enterprise:6.0"
           - "unleashorg/unleash-server:6.0"
+          - "ghcr.io/ivarconr/unleash-enterprise:6.1"
+          - "unleashorg/unleash-server:6.1"
           - "ghcr.io/ivarconr/unleash-enterprise:latest"
           - "unleashorg/unleash-server:latest"
     runs-on: ubuntu-latest


### PR DESCRIPTION
Drops official support for 5.8 and below and adds support for 6.1

5.8 and below made changes the way OIDC/SAML default roles were handled. Previously they were strings (e.g. "Admin", "Editor" etc(, they were migrated to the id of the role in a new property. However the old property has no effect and is ignored from 5.9 and above, whereas in the older versions, the new property is never sent back. It's quite hard to get a compiling version of the API that works with both of these and I think it's not possible without version awareness. Probably not worth it though